### PR TITLE
Fix double semicolon in MainApp

### DIFF
--- a/src/main/java/gr/mmam/myHouseholdEconomy/MainApp.java
+++ b/src/main/java/gr/mmam/myHouseholdEconomy/MainApp.java
@@ -230,7 +230,7 @@ public class MainApp extends Application {
 			controller.setMainApp(this);
 			controller.setMonth(month);
 			controller.setYear(year);
-			controller.initialize();;
+                        controller.initialize();
 		} catch (IOException e) {
 			Stacktrace.print(e);
 		}


### PR DESCRIPTION
## Summary
- remove a stray semicolon in `MainApp.showStatistics`

## Testing
- `mvn -q test` *(fails: Could not transfer artifact maven-resources-plugin due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6866ab38aae88328b8bedd6ec3e3209b