### PR TITLE
Fix currency selection check

### DIFF
--- a/src/main/java/gr/mmam/myHouseholdEconomy/view/OptionsController.java
+++ b/src/main/java/gr/mmam/myHouseholdEconomy/view/OptionsController.java
@@ -68,7 +68,7 @@ public class OptionsController {
 		loadExcelBtn.setDisable(true);
 		changeCurrencyBtn.setOnAction(new EventHandler<ActionEvent>() {
 			public void handle(ActionEvent event) {
-				if (currency.getSelectionModel().getSelectedItem()!= null && currency.getSelectionModel().getSelectedItem()!= "") {
+				if (currency.getSelectionModel().getSelectedItem()!= null && !currency.getSelectionModel().getSelectedItem().isEmpty()) {
 					setCurrency(currency.getSelectionModel().getSelectedItem());
 				}
 			}
@@ -130,7 +130,7 @@ public class OptionsController {
 	
 	private void initializeCurrency() {
 		currency.getItems().clear();
-		currency.getItems().add("€");
+		currency.getItems().add("â‚¬");
 		currency.getItems().add("$");
 		currency.getSelectionModel().select(optionsDao.getCurrency());
 	}


### PR DESCRIPTION
## Summary
- avoid string reference comparison when changing currency in OptionsController

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866ab3e4fb8832886fa6f517af87cc9