### PR TITLE
Remove unused generic from TransactionController

### DIFF
--- a/src/main/java/gr/mmam/myHouseholdEconomy/view/TransactionController.java
+++ b/src/main/java/gr/mmam/myHouseholdEconomy/view/TransactionController.java
@@ -60,7 +60,7 @@ import javafx.scene.text.Text;
 import javafx.util.Callback;
 import javafx.util.StringConverter;
 
-public class TransactionController<JFXButton> {
+public class TransactionController {
 
 	MainController mainController = new MainController();
 


### PR DESCRIPTION
## Summary
- clean up the TransactionController class declaration by removing an unused generic parameter

## Testing
- `mvn -q -DskipTests package` *(fails: Plugin dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6866ab4fc7e48328a91a2f6cde46f5f0