### PR TITLE
Refactor FXML background colors to CSS classes

### DIFF
--- a/src/main/resources/css/theme.css
+++ b/src/main/resources/css/theme.css
@@ -1,0 +1,18 @@
+.bg-primary {
+    -fx-background-color: #434f63;
+}
+
+.bg-secondary {
+    -fx-background-color: #3C659D;
+}
+
+.bg-transparent {
+    -fx-background-color: transparent;
+}
+
+.bottom-bar {
+    -fx-background-color: #434f63;
+    -fx-border-style: solid none none none;
+    -fx-border-color: gray;
+}
+

--- a/src/main/resources/view/MainView.fxml
+++ b/src/main/resources/view/MainView.fxml
@@ -9,9 +9,9 @@
 <?import javafx.scene.text.Font?>
 <?import javafx.scene.text.Text?>
 
-<BorderPane prefHeight="600.0" prefWidth="800.0" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="gr.mmam.myHouseholdEconomy.view.MainController">
+<BorderPane stylesheets="@../css/theme.css" prefHeight="600.0" prefWidth="800.0" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="gr.mmam.myHouseholdEconomy.view.MainController">
    <bottom>
-      <AnchorPane prefHeight="27.0" prefWidth="800.0" style="-fx-background-color: #434f63; -fx-border-style: solid none none none; -fx-border-color: gray;" BorderPane.alignment="CENTER">
+      <AnchorPane prefHeight="27.0" prefWidth="800.0" styleClass="bottom-bar" BorderPane.alignment="CENTER">
          <children>
             <Pane prefHeight="28.0" prefWidth="800.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
                <children>
@@ -23,7 +23,7 @@
       </AnchorPane>
    </bottom>
    <left>
-      <AnchorPane prefHeight="572.0" prefWidth="238.0" style="-fx-background-color: #434f63;" stylesheets="@../css/main.css" BorderPane.alignment="CENTER">
+      <AnchorPane prefHeight="572.0" prefWidth="238.0" styleClass="bg-primary" stylesheets="@../css/main.css" BorderPane.alignment="CENTER">
          <children>
             <Pane layoutX="19.0" layoutY="14.0" prefHeight="190.0" prefWidth="200.0">
                <children>
@@ -44,7 +44,7 @@
                   </ImageView>
                </children>
             </Pane>
-            <Button fx:id="homeBtn" alignment="TOP_LEFT" layoutX="-7.0" layoutY="231.0" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" mnemonicParsing="false" prefHeight="44.0" prefWidth="300.0" style="-fx-background-color: transparent;" text=" Overview" textFill="#dadada" textOverrun="CLIP" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
+            <Button fx:id="homeBtn" alignment="TOP_LEFT" layoutX="-7.0" layoutY="231.0" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" mnemonicParsing="false" prefHeight="44.0" prefWidth="300.0" styleClass="bg-transparent" text=" Overview" textFill="#dadada" textOverrun="CLIP" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
                <font>
                   <Font name="Calibri" size="24.0" />
                </font>
@@ -56,7 +56,7 @@
                   </ImageView>
                </graphic>
             </Button>
-            <Button fx:id="incomeListBtn" alignment="TOP_LEFT" layoutY="361.0" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" mnemonicParsing="false" prefHeight="44.0" prefWidth="276.0" style="-fx-background-color: transparent;" text=" Income Categories" textFill="#dadada" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
+            <Button fx:id="incomeListBtn" alignment="TOP_LEFT" layoutY="361.0" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" mnemonicParsing="false" prefHeight="44.0" prefWidth="276.0" styleClass="bg-transparent" text=" Income Categories" textFill="#dadada" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
                <font>
                   <Font name="Calibri" size="24.0" />
                </font>
@@ -68,7 +68,7 @@
                   </ImageView>
                </graphic>
             </Button>
-            <Button fx:id="statisticsBtn" alignment="TOP_LEFT" layoutY="405.0" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" mnemonicParsing="false" prefHeight="44.0" prefWidth="276.0" style="-fx-background-color: transparent;" text=" Statistics" textFill="#dadada" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
+            <Button fx:id="statisticsBtn" alignment="TOP_LEFT" layoutY="405.0" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" mnemonicParsing="false" prefHeight="44.0" prefWidth="276.0" styleClass="bg-transparent" text=" Statistics" textFill="#dadada" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
                <font>
                   <Font name="Calibri" size="24.0" />
                </font>
@@ -80,7 +80,7 @@
                   </ImageView>
                </graphic>
             </Button>
-            <Button fx:id="capitalBtn" alignment="TOP_LEFT" layoutY="493.0" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" mnemonicParsing="false" prefHeight="44.0" prefWidth="276.0" style="-fx-background-color: transparent;" text=" Checkpoint" textFill="#dadada" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
+            <Button fx:id="capitalBtn" alignment="TOP_LEFT" layoutY="493.0" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" mnemonicParsing="false" prefHeight="44.0" prefWidth="276.0" styleClass="bg-transparent" text=" Checkpoint" textFill="#dadada" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
                <font>
                   <Font name="Calibri" size="24.0" />
                </font>
@@ -92,7 +92,7 @@
                   </ImageView>
                </graphic>
             </Button>
-            <Button fx:id="optionsBtn" alignment="TOP_LEFT" layoutY="449.0" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" mnemonicParsing="false" prefHeight="44.0" prefWidth="276.0" style="-fx-background-color: transparent;" text=" Options" textFill="#dadada" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
+            <Button fx:id="optionsBtn" alignment="TOP_LEFT" layoutY="449.0" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" mnemonicParsing="false" prefHeight="44.0" prefWidth="276.0" styleClass="bg-transparent" text=" Options" textFill="#dadada" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
                <font>
                   <Font name="Calibri" size="24.0" />
                </font>
@@ -104,7 +104,7 @@
                   </ImageView>
                </graphic>
             </Button>
-            <Button fx:id="expensesBtn" alignment="TOP_LEFT" layoutX="7.0" layoutY="275.0" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" mnemonicParsing="false" prefHeight="36.0" prefWidth="276.0" style="-fx-background-color: transparent;" text=" Transactions" textFill="#dadada" textOverrun="CLIP" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
+            <Button fx:id="expensesBtn" alignment="TOP_LEFT" layoutX="7.0" layoutY="275.0" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" mnemonicParsing="false" prefHeight="36.0" prefWidth="276.0" styleClass="bg-transparent" text=" Transactions" textFill="#dadada" textOverrun="CLIP" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
                <font>
                   <Font name="Calibri" size="24.0" />
                </font>
@@ -116,7 +116,7 @@
                   </ImageView>
                </graphic>
             </Button>
-            <Button fx:id="categoriesListBtn" alignment="TOP_LEFT" layoutX="-1.0" layoutY="319.0" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" mnemonicParsing="false" prefHeight="44.0" prefWidth="276.0" style="-fx-background-color: transparent;" text=" Expense Categories" textFill="#dadada">
+            <Button fx:id="categoriesListBtn" alignment="TOP_LEFT" layoutX="-1.0" layoutY="319.0" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" mnemonicParsing="false" prefHeight="44.0" prefWidth="276.0" styleClass="bg-transparent" text=" Expense Categories" textFill="#dadada">
                <font>
                   <Font name="Calibri" size="24.0" />
                </font>

--- a/src/main/resources/view/OverView.fxml
+++ b/src/main/resources/view/OverView.fxml
@@ -11,7 +11,7 @@
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.text.Font?>
 
-<AnchorPane maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" style="-fx-background-color: #434f63;" xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml" fx:controller="gr.mmam.myHouseholdEconomy.view.OverviewController">
+<AnchorPane maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" styleClass="bg-primary" stylesheets="@../css/theme.css,@../css/overviewCSS.css" xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml" fx:controller="gr.mmam.myHouseholdEconomy.view.OverviewController">
    <children>
       <GridPane hgap="5.0" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" prefHeight="509.0" prefWidth="800.0" vgap="5.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
         <columnConstraints>
@@ -23,7 +23,7 @@
           <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
         </rowConstraints>
          <children>
-            <AnchorPane prefHeight="200.0" prefWidth="200.0" style="-fx-background-color: #3C659D;" GridPane.columnIndex="1">
+            <AnchorPane prefHeight="200.0" prefWidth="200.0" styleClass="bg-secondary" GridPane.columnIndex="1">
                <children>
                   <Pane fx:id="monthlyHouseholdPane" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" prefHeight="250.0" prefWidth="400.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                      <children>
@@ -66,7 +66,7 @@
                   </Pane>
                </children>
             </AnchorPane>
-            <AnchorPane prefHeight="200.0" prefWidth="200.0" style="-fx-background-color: #3C659D;" GridPane.columnIndex="1" GridPane.rowIndex="1">
+            <AnchorPane prefHeight="200.0" prefWidth="200.0" styleClass="bg-secondary" GridPane.columnIndex="1" GridPane.rowIndex="1">
                <children>
                   <Pane fx:id="monthlyTopPane" prefHeight="250.0" prefWidth="400.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                      <children>
@@ -85,7 +85,7 @@
                   </Pane>
                </children>
             </AnchorPane>
-            <AnchorPane prefHeight="200.0" prefWidth="200.0" style="-fx-background-color: #3C659D;" GridPane.rowIndex="1">
+            <AnchorPane prefHeight="200.0" prefWidth="200.0" styleClass="bg-secondary" GridPane.rowIndex="1">
                <children>
                   <Pane fx:id="yearlyTopPane" prefHeight="250.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                      <children>
@@ -104,9 +104,9 @@
                   </Pane>
                </children>
             </AnchorPane>
-            <AnchorPane prefHeight="200.0" prefWidth="200.0" style="-fx-background-color: #3C659D;">
+            <AnchorPane prefHeight="200.0" prefWidth="200.0" styleClass="bg-secondary">
                <children>
-                  <Pane fx:id="yearlyHouseholdPane" prefHeight="250.0" prefWidth="400.0" style="-fx-background-color: #3C659D;" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+                  <Pane fx:id="yearlyHouseholdPane" prefHeight="250.0" prefWidth="400.0" styleClass="bg-secondary" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                      <children>
                         <Label fx:id="yearlyHouseholdLabel" alignment="CENTER" layoutX="123.0" layoutY="14.0" text="Yearly Household" textFill="WHITE">
                            <font>

--- a/src/main/resources/view/StatisticsView.fxml
+++ b/src/main/resources/view/StatisticsView.fxml
@@ -12,7 +12,7 @@
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.text.Font?>
 
-<AnchorPane maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" style="-fx-background-color: #434f63;" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="gr.mmam.myHouseholdEconomy.view.StatisticsController">
+<AnchorPane maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" styleClass="bg-primary" stylesheets="@../css/theme.css,@../css/overviewCSS.css" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="gr.mmam.myHouseholdEconomy.view.StatisticsController">
    <children>
       <GridPane hgap="5.0" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" prefHeight="509.0" prefWidth="800.0" vgap="5.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
         <columnConstraints>
@@ -24,7 +24,7 @@
           <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
         </rowConstraints>
          <children>
-            <AnchorPane prefHeight="200.0" prefWidth="200.0" style="-fx-background-color: #3C659D;" GridPane.columnIndex="1">
+            <AnchorPane prefHeight="200.0" prefWidth="200.0" styleClass="bg-secondary" GridPane.columnIndex="1">
                <children>
                   <GridPane AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                     <columnConstraints>
@@ -59,8 +59,8 @@
                   </GridPane>
                </children>
             </AnchorPane>
-            <AnchorPane prefHeight="200.0" prefWidth="200.0" style="-fx-background-color: #3C659D;" GridPane.columnIndex="1" GridPane.rowIndex="1" />
-            <AnchorPane prefHeight="200.0" prefWidth="200.0" style="-fx-background-color: #3C659D;" GridPane.rowIndex="1">
+            <AnchorPane prefHeight="200.0" prefWidth="200.0" styleClass="bg-secondary" GridPane.columnIndex="1" GridPane.rowIndex="1" />
+            <AnchorPane prefHeight="200.0" prefWidth="200.0" styleClass="bg-secondary" GridPane.rowIndex="1">
                <children>
                   <GridPane AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                     <columnConstraints>
@@ -79,7 +79,7 @@
                         </TableView>
                      </children>
                   </GridPane>
-                  <Pane fx:id="yearlyHouseholdPane1" layoutX="10.0" layoutY="10.0" maxHeight="50.0" prefHeight="10.0" prefWidth="397.0" style="-fx-background-color: #3C659D;">
+                  <Pane fx:id="yearlyHouseholdPane1" layoutX="10.0" layoutY="10.0" maxHeight="50.0" prefHeight="10.0" prefWidth="397.0" styleClass="bg-secondary">
                      <children>
                         <Label id="test1" fx:id="yearExpenseLbl1" alignment="CENTER" layoutX="129.0" layoutY="-12.0" text="Sum By Year" textFill="WHITE">
                            <font>
@@ -90,7 +90,7 @@
                   </Pane>
                </children>
             </AnchorPane>
-            <AnchorPane prefHeight="200.0" prefWidth="200.0" style="-fx-background-color: #3C659D;">
+            <AnchorPane prefHeight="200.0" prefWidth="200.0" styleClass="bg-secondary">
                <children>
                   <GridPane id="expenseYearGrid" fx:id="expenseYearGrid" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                     <columnConstraints>
@@ -101,7 +101,7 @@
                       <RowConstraints maxHeight="214.9999917348226" minHeight="10.0" prefHeight="214.9999917348226" vgrow="SOMETIMES" />
                     </rowConstraints>
                      <children>
-                        <Pane fx:id="yearlyHouseholdPane" maxHeight="50.0" prefHeight="10.0" prefWidth="397.0" style="-fx-background-color: #3C659D;" GridPane.hgrow="ALWAYS">
+                        <Pane fx:id="yearlyHouseholdPane" maxHeight="50.0" prefHeight="10.0" prefWidth="397.0" styleClass="bg-secondary" GridPane.hgrow="ALWAYS">
                            <children>
                               <Label id="test1" fx:id="yearExpenseLbl" alignment="CENTER" layoutX="49.0" layoutY="6.0" text="Expenses of Year $Year" textFill="WHITE">
                                  <font>


### PR DESCRIPTION
## Summary
- extract inline background styles into `theme.css`
- reference CSS classes from FXML files
- ensure FXML imports `theme.css`

## Testing
- `mvn -q -DskipTests=false test` *(fails: `mvn` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866b26972e883288059253f88d8fbc5